### PR TITLE
Add Content-Type header to Key Server XHR

### DIFF
--- a/GenerateKeyUsingKeyServer.js
+++ b/GenerateKeyUsingKeyServer.js
@@ -49,6 +49,7 @@
 	
 	let xhr = new XMLHttpRequest();
 	xhr.open("POST", keyServerUrl, true);
+	xhr.setRequestHeader('Content-Type', 'application/json');
 	
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState === 4) {


### PR DESCRIPTION
Using the new Key Server URL, requests without a proper `Content-Type` header will fail with HTTP status 415 (Unsupported Media Type). The old endpoint apparently was more permissive and accepted various encodings or simply defaulted to JSON.

This was tested on a Macbook using node v8.9.1 and npm 5.6.0, which should be more or less up to date, as well as an older installation of node ~7.1.